### PR TITLE
Add class skipping based on regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-JAPIT
-=====
+# JAPIT
 
 JavaAPITools - set of utilities to list, compare public APIs and other details for available classes and jar files
 
-* org.jboss.japit.ListAPIMain -- list public methods, fields, class details for specified jar files
-* org.jboss.japit.CompareAPIMain -- compare two jar files on public methods, fields and class details
+* `org.jboss.japit.ListAPIMain` -- list public methods, fields, class details for specified jar files
+* `org.jboss.japit.CompareAPIMain` -- compare two jar files on public methods, fields and class details
 
 Output:
 * console
@@ -12,41 +11,59 @@ Output:
 * HTML files
 
 
-Building
--------------------
+## Building
 
-Ensure you have Maven installed, maven-shade-plugin packages all dependencies in final jar
+Ensure you have Maven installed. The `maven-shade-plugin` packages all dependencies in the final jar (Überjar).
 
-> mvn clean package
+```bash
+mvn clean package
+```
 
-Executing Maven Way
-------------------------------------------
-> mvn exec:java -Dexec.mainClass="org.jboss.japit.ListAPIMain" -Dexec.args="arg0 arg1 arg2"
+## Executing Maven Way
 
-Executing Command Line Way
-------------------------------------------
-> java -jar japit.jar -cmd (--command) [COMPARE | LIST] [command arguments]
+```bash
+mvn exec:java -Dexec.mainClass="org.jboss.japit.ListAPIMain" -Dexec.args="arg0 arg1 arg2"
+```
 
-LIST command syntax (java org.jboss.japit.ListAPIMain)
-------------------------------------------
+## Executing Command Line Way
+
+```bash
+java -jar japit.jar -cmd (--command) [COMPARE | LIST] [command arguments]
+```
+
+### Real life example
+
+```bash
+# Compare two versions of an awesome library, but skip:
+# - classes from internal packages (includes ".internal." in name)
+# - and anonymous classes (e.g. org.awesome.Type$1)
+java -jar japit.jar -cmd COMPARE -r .*\\.internal\\..* -r .*\\\$[0-9]+ -h /tmp/japit-html awesome-1.0.{0,1}.jar
+```
+
+## LIST command syntax (java org.jboss.japit.ListAPIMain)
+
 ```
  -c (--class) FQCN             : List API only for specified class
  -d (--disable-console-output) : Disable text output to the console
  -h (--html-output) DIR        : Enable HTML output and set output directory
+ -r (--skip-regex) REGEX        : Don't list API for class names matching given
+                                  regular expression
  -t (--txt-output) DIR         : Enable TXT output and set output directory
 
   Example: java org.jboss.japit.ListAPIMain -c (--class) FQCN -d (--disable-console-output) -h 
   (--html-output) DIR -t (--txt-output) DIR  JarFile1 [JarFile2 ...]
 ```
 
-COMPARE command syntax (java org.jboss.japit.CompareAPIMain)
-------------------------------------------
+## COMPARE command syntax (java org.jboss.japit.CompareAPIMain)
+
 ```
  -c (--class) FQCN              : List API only for specified class
  -d (--disable-console-output)  : Disable text output to the console
  -e (--enable-declared-items)   : Enable declared methods and fiels in comparison
  -h (--html-output) DIR         : Enable HTML output and set output directory
  -i (--ignore-class-version)    : Ignore class version in comparison
+ -r (--skip-regex) REGEX        : Don't list API for class names matching given
+                                  regular expression
  -s (--suppress-archive-report) : Suppress archive reports in output
  -t (--txt-output) DIR          : Enable TXT output and set output directory
 
@@ -55,6 +72,6 @@ COMPARE command syntax (java org.jboss.japit.CompareAPIMain)
   -t (--txt-output) DIR  FirstPairFirstJar FirstPairSecondJar [SecondPairFirstJar SecondPairSecondJar ...]
 ```
 
-License
-------------------------------------------
+## License
+
 * [GNU Lesser General Public License Version 2.1](http://www.gnu.org/licenses/lgpl-2.1-standalone.html)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.jboss</groupId>
     <artifactId>japit</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JavaAPITools</name>
@@ -45,8 +45,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.maven-compiler-plugin}</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/jboss/japit/BasicOptions.java
+++ b/src/main/java/org/jboss/japit/BasicOptions.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.japit;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.Option;
+
+/**
+ * Abstract parent for Options classes.
+ */
+public abstract class BasicOptions {
+
+    @Option(name = "-c", aliases = {"--class"}, usage = "List API only for specified class", metaVar = "FQCN")
+    private String selectedFQCN;
+    @Option(name = "-r", aliases = {"--skip-regex"}, usage = "Don't list API for class names matching given regular expression", metaVar = "REGEX")
+    private List<String> skipRegex;
+    @Option(name = "-d", aliases = {"--disable-console-output"}, usage = "Disable text output to the console")
+    private boolean textOutputDisbled = false;
+    @Option(name = "-h", aliases = {"--html-output"}, usage = "Enable HTML output and set output directory", metaVar = "DIR")
+    private File htmlOutputDir;
+    @Option(name = "-t", aliases = {"--txt-output"}, usage = "Enable TXT output and set output directory", metaVar = "DIR")
+    private File txtOutputDir;
+    // receives other command line parameters than options
+    @Argument
+    private List<String> arguments = new ArrayList<String>();
+
+    public List<String> getArguments() {
+        return arguments;
+    }
+
+    public String getSelectedFQCN() {
+        return selectedFQCN;
+    }
+
+    public boolean isTextOutputDisbled() {
+        return textOutputDisbled;
+    }
+
+    public File getHtmlOutputDir() {
+        return htmlOutputDir;
+    }
+
+    public File getTxtOutputDir() {
+        return txtOutputDir;
+    }
+    
+    
+
+    public List<String> getSkipRegex() {
+        return skipRegex;
+    }
+
+    protected String attributesToString() {
+        return "selectedFQCN=" + selectedFQCN + ", "
+                + "skipRegex=" + skipRegex + ", "
+                + "textOutputDisbled=" + textOutputDisbled + ", "
+                + "htmlOutputDir=" + htmlOutputDir + ", "
+                + "txtOutputDir=" + txtOutputDir + ", "
+                + "arguments=" + arguments;
+    }
+}

--- a/src/main/java/org/jboss/japit/CompareAPIMain.java
+++ b/src/main/java/org/jboss/japit/CompareAPIMain.java
@@ -87,7 +87,7 @@ public class CompareAPIMain {
             return;
         }
 
-        List<Archive> jarArchives = JarAnalyser.analyseJars(inputFiles, options.getSelectedFQCN());
+        List<Archive> jarArchives = new JarAnalyser(options).analyseJars(inputFiles);
 
         if (!(jarArchives.get(0) instanceof JarArchive)) {
             throw new UnsupportedOperationException("Can't generate reports, "

--- a/src/main/java/org/jboss/japit/CompareAPIMainOptions.java
+++ b/src/main/java/org/jboss/japit/CompareAPIMainOptions.java
@@ -21,55 +21,20 @@
  */
 package org.jboss.japit;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.Option;
 
 /**
  *
  * @author Rostislav Svoboda
  */
-public class CompareAPIMainOptions {
+public class CompareAPIMainOptions extends BasicOptions {
 
-    @Option(name = "-c", aliases = {"--class"}, usage = "List API only for specified class", metaVar = "FQCN")
-    private String selectedFQCN;
-    @Option(name = "-d", aliases = {"--disable-console-output"}, usage = "Disable text output to the console")
-    private boolean textOutputDisbled = false;
     @Option(name = "-i", aliases = {"--ignore-class-version"}, usage = "Ignore class version in comparison")
     private boolean ignoreClassVersion = false;
     @Option(name = "-s", aliases = {"--suppress-archive-report"}, usage = "Suppress archive reports in output")
     private boolean suppressArchiveReport = false;
     @Option(name = "-e", aliases = {"--enable-declared-items"}, usage = "Enable declared methods and fiels in comparison")
     private boolean enableDeclaredItems = false;
-    @Option(name = "-h", aliases = {"--html-output"}, usage = "Enable HTML output and set output directory", metaVar = "DIR")
-    private File htmlOutputDir;
-    @Option(name = "-t", aliases = {"--txt-output"}, usage = "Enable TXT output and set output directory", metaVar = "DIR")
-    private File txtOutputDir;
-    // receives other command line parameters than options
-    @Argument
-    private List<String> arguments = new ArrayList<String>();
-
-    public List<String> getArguments() {
-        return arguments;
-    }
-
-    public String getSelectedFQCN() {
-        return selectedFQCN;
-    }
-
-    public boolean isTextOutputDisbled() {
-        return textOutputDisbled;
-    }
-
-    public File getHtmlOutputDir() {
-        return htmlOutputDir;
-    }
-
-    public File getTxtOutputDir() {
-        return txtOutputDir;
-    }
 
     public boolean isIgnoreClassVersion() {
         return ignoreClassVersion;
@@ -82,15 +47,12 @@ public class CompareAPIMainOptions {
     public boolean isEnableDeclaredItems() {
         return enableDeclaredItems;
     }
-    
+
     @Override
     public String toString() {
-        return "ListAPIMainOptions{" + "selectedFQCN=" + selectedFQCN + ", "
-                + "textOutputDisbled=" + textOutputDisbled + ", "
-                + "ignoreClassVersion=" + ignoreClassVersion + ", "
-                + "suppressArchiveReport=" + suppressArchiveReport + ", "
-                + "htmlOutputDir=" + htmlOutputDir + ", "
-                + "txtOutputDir=" + txtOutputDir + ", "
-                + "arguments=" + arguments + '}';
+        return "CompareAPIMainOptions{" + attributesToString()
+            + "enableDeclaredItems=" + enableDeclaredItems + ", "
+            + "ignoreClassVersion=" + ignoreClassVersion + ", "
+            + "suppressArchiveReport=" + suppressArchiveReport + '}';
     }
 }

--- a/src/main/java/org/jboss/japit/ListAPIMain.java
+++ b/src/main/java/org/jboss/japit/ListAPIMain.java
@@ -82,7 +82,7 @@ public class ListAPIMain {
             return;
         }
 
-        List<Archive> jarArchives = JarAnalyser.analyseJars(inputFiles, options.getSelectedFQCN());
+        List<Archive> jarArchives = new JarAnalyser(options).analyseJars(inputFiles);
 
         Reporting.generateReports(jarArchives, options.isTextOutputDisbled(), options.getTxtOutputDir(), options.getHtmlOutputDir());
 

--- a/src/main/java/org/jboss/japit/ListAPIMainOptions.java
+++ b/src/main/java/org/jboss/japit/ListAPIMainOptions.java
@@ -21,56 +21,14 @@
  */
 package org.jboss.japit;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.Option;
-
 /**
  *
  * @author Rostislav Svoboda
  */
-public class ListAPIMainOptions {
-
-    @Option(name = "-c", aliases = {"--class"}, usage = "List API only for specified class", metaVar = "FQCN")
-    private String selectedFQCN;
-    @Option(name = "-d", aliases = {"--disable-console-output"}, usage = "Disable text output to the console")
-    private boolean textOutputDisbled = false;
-    @Option(name = "-h", aliases = {"--html-output"}, usage = "Enable HTML output and set output directory", metaVar = "DIR")
-    private File htmlOutputDir;
-    @Option(name = "-t", aliases = {"--txt-output"}, usage = "Enable TXT output and set output directory", metaVar = "DIR")
-    private File txtOutputDir;
-    // receives other command line parameters than options
-    @Argument
-    private List<String> arguments = new ArrayList<String>();
-
-    public List<String> getArguments() {
-        return arguments;
-    }
-
-    public String getSelectedFQCN() {
-        return selectedFQCN;
-    }
-
-    public boolean isTextOutputDisbled() {
-        return textOutputDisbled;
-    }
-
-    public File getHtmlOutputDir() {
-        return htmlOutputDir;
-    }
-
-    public File getTxtOutputDir() {
-        return txtOutputDir;
-    }
+public class ListAPIMainOptions extends BasicOptions {
 
     @Override
     public String toString() {
-        return "ListAPIMainOptions{" + "selectedFQCN=" + selectedFQCN + ", "
-                + "textOutputDisbled=" + textOutputDisbled + ", "
-                + "htmlOutputDir=" + htmlOutputDir + ", "
-                + "txtOutputDir=" + txtOutputDir + ", "
-                + "arguments=" + arguments + '}';
+        return "ListAPIMainOptions{" + attributesToString() + '}';
     }
 }

--- a/src/main/java/org/jboss/japit/analyser/JarAnalyser.java
+++ b/src/main/java/org/jboss/japit/analyser/JarAnalyser.java
@@ -26,19 +26,30 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.jboss.japit.BasicOptions;
+import org.jboss.japit.core.Archive;
+import org.jboss.japit.core.ClassDetails;
+import org.jboss.japit.core.JarArchive;
+
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.CtField;
 import javassist.CtMethod;
 import javassist.Modifier;
 import javassist.NotFoundException;
-import org.jboss.japit.core.Archive;
-import org.jboss.japit.core.ClassDetails;
-import org.jboss.japit.core.JarArchive;
 
 /**
  *
@@ -46,85 +57,44 @@ import org.jboss.japit.core.JarArchive;
  */
 public class JarAnalyser {
 
-    public static List<Archive> analyseJars(List<File> inputFiles, String selectedFQCN) {
+    private final BasicOptions options;
+    private final List<Pattern> skipPatterns = new ArrayList<>();
+
+    public JarAnalyser(BasicOptions options) {
+        this.options = options;
+        if (options.getSkipRegex() != null) {
+            for (String str : options.getSkipRegex()) {
+                skipPatterns.add(Pattern.compile(str));
+            }
+        }
+    }
+
+    public List<Archive> analyseJars(List<File> inputFiles) {
         List<Archive> jarArchives = new ArrayList<Archive>(inputFiles.size());
 
         for (File file : inputFiles) {
+            try (JarFile jar = new JarFile(file)) {
+                JarArchive jarArchive = new JarArchive(file.getName(), file.getCanonicalPath());
+                Enumeration<JarEntry> jarEntries = jar.entries();
+                TreeSet<ClassDetails> classes = enumerationAsStream(jarEntries)
+                        .map(je -> createOptionalClassDetail(jar, je))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(Collectors.toCollection(TreeSet::new));
 
-            JarFile jar = null;
-            JarArchive jarArchive = null;
-            try {
-                jar = new JarFile(file);
-                jarArchive = new JarArchive(file.getName(), file.getCanonicalPath());
+                jarArchive.setClasses(classes);
+                jarArchives.add(jarArchive);
             } catch (IOException ex) {
                 System.err.println(file.getName() + " is not regular jar file, skipping it.");
                 ex.printStackTrace(System.err);
-                continue;
-            }
-            TreeSet<ClassDetails> classes = new TreeSet<ClassDetails>();
-
-            Enumeration<JarEntry> jarEntries = jar.entries();
-            while (jarEntries.hasMoreElements()) {
-                JarEntry jarEntry = jarEntries.nextElement();
-                String entryName = jarEntry.getName();
-                InputStream entryStream = null;
-                if (entryName.endsWith(".class")) {
-                    try {
-                        entryStream = jar.getInputStream(jarEntry);
-
-                        ClassPool classPool = new ClassPool(true);
-                        CtClass ctClz = classPool.makeClass(entryStream);
-
-                        if (selectedFQCN == null || ctClz.getName().equals(selectedFQCN)) {
-
-                            ClassDetails classArchive = new ClassDetails(Modifier.toString(ctClz.getModifiers()) + " " + ctClz.getName());
-                            classArchive.setClassVersion(ctClz.getClassFile().getMajorVersion());
-                            classArchive.setSuperclassName(ctClz.getClassFile().getSuperclass());
-                            classArchive.setReferencedClasses(ctClz.getRefClasses().size());
-                            classArchive.setOriginalJavaFile(ctClz.getClassFile().getSourceFile());
-                            classArchive.setDeclaredMethodsCount(ctClz.getDeclaredMethods().length);
-                            classArchive.setDeclaredFieldsCount(ctClz.getDeclaredFields().length);
-                            
-                            TreeSet<String> methods = new TreeSet<String>();
-                            for (CtMethod method : ctClz.getMethods()) {
-                                methods.add(Modifier.toString(method.getModifiers()) + " " + getReturnTypeName(method)
-                                        + " " + method.getLongName());
-                            }
-                            classArchive.setMethods(methods);
-
-                            TreeSet<String> fields = new TreeSet<String>();
-                            for (CtField field : ctClz.getFields()) {
-                                fields.add(Modifier.toString(field.getModifiers()) + " " + field.getFieldInfo().toString());
-                            }
-                            classArchive.setFields(fields);
-
-                            classes.add(classArchive);
-                        }
-                    } catch (Throwable ie) {
-                        System.err.println("Exception thrown when processing " + entryName);
-                        ie.printStackTrace(System.err);
-                    } finally {
-                        if (entryStream != null) {
-                            try {
-                                entryStream.close();
-                            } catch (IOException ex) {
-                                System.err.println("EntryStream couldn't be closed for " + entryName);
-                                ex.printStackTrace(System.err);
-                            }
-                        }
-                    }
-                }
             }
 
-            jarArchive.setClasses(classes);
-
-            jarArchives.add(jarArchive);
         }
 
         return jarArchives;
     }
 
-    private static String getReturnTypeName(final CtMethod method) {
+    private String getReturnTypeName(final CtMethod method) {
         try {
             return method.getReturnType().getName();
         } catch (NotFoundException ex) {
@@ -132,5 +102,82 @@ public class JarAnalyser {
             // getMessage() contains the full class name
             return ex.getMessage();
         }
+    }
+
+    /**
+     * Provides stream view on given {@link Enumeration}.
+     */
+    private <T> Stream<T> enumerationAsStream(Enumeration<T> e) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<T>() {
+            public T next() {
+                return e.nextElement();
+            }
+
+            public boolean hasNext() {
+                return e.hasMoreElements();
+            }
+        }, Spliterator.ORDERED), false);
+    }
+
+    /**
+     * Creates {@link ClassDetails} instance wrapped as {@link Optional} for not-to-be-skipped class entries in the jar. For
+     * non-class entries and skippable classes returns an empty {@link Optional}.
+     */
+    private Optional<ClassDetails> createOptionalClassDetail(JarFile jar, JarEntry jarEntry) {
+        String entryName = jarEntry.getName();
+        if (!entryName.endsWith(".class")) {
+            return Optional.empty();
+        }
+
+        ClassDetails classDetails = null;
+        try (InputStream entryStream = jar.getInputStream(jarEntry)) {
+            ClassPool classPool = new ClassPool(true);
+            CtClass ctClz = classPool.makeClass(entryStream);
+            String className = ctClz.getName();
+
+            if (skipClassName(className)) {
+                return Optional.empty();
+            }
+            classDetails = new ClassDetails(Modifier.toString(ctClz.getModifiers()) + " " + className);
+            classDetails.setClassVersion(ctClz.getClassFile().getMajorVersion());
+            classDetails.setSuperclassName(ctClz.getClassFile().getSuperclass());
+            classDetails.setReferencedClasses(ctClz.getRefClasses().size());
+            classDetails.setOriginalJavaFile(ctClz.getClassFile().getSourceFile());
+            classDetails.setDeclaredMethodsCount(ctClz.getDeclaredMethods().length);
+            classDetails.setDeclaredFieldsCount(ctClz.getDeclaredFields().length);
+
+            TreeSet<String> methods = new TreeSet<String>();
+            for (CtMethod method : ctClz.getMethods()) {
+                methods.add(Modifier.toString(method.getModifiers()) + " " + getReturnTypeName(method) + " "
+                        + method.getLongName());
+            }
+            classDetails.setMethods(methods);
+
+            TreeSet<String> fields = new TreeSet<String>();
+            for (CtField field : ctClz.getFields()) {
+                fields.add(Modifier.toString(field.getModifiers()) + " " + field.getFieldInfo().toString());
+            }
+            classDetails.setFields(fields);
+        } catch (Throwable ie) {
+            System.err.println("Exception thrown when processing " + entryName);
+            ie.printStackTrace(System.err);
+        }
+        return Optional.ofNullable(classDetails);
+    }
+
+    /**
+     * Returns true if the given classname should be skipped based on this analyzer options.
+     */
+    private boolean skipClassName(String className) {
+        final String selectedFQCN = options.getSelectedFQCN();
+        if (selectedFQCN != null && !selectedFQCN.equals(className)) {
+            return true;
+        }
+        for (Pattern skipPattern : skipPatterns) {
+            if (skipPattern.matcher(className).matches()) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Resolves #6.

This PR comes with 2 commits:
* first updates Japit to use Java 8 
* the second adds possibility to skip classes which fits a regular expression

Sample:
```bash
# skip classes from internal packages (includes .internal. in name) and anonymous classes (e.g. Type$1)
java -jar japit.jar -cmd COMPARE -r .*\\.internal\\..* -r .*\\\$[0-9]+ -h /tmp/japit-html awesome-1.0.{0,1}.jar
```